### PR TITLE
Removed old Twig_TokenStream::getFilename call in AsseticTokenParser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "kriswallsmith/assetic",
+    "name": "assetic/framework",
     "description": "Asset Management for PHP",
-    "keywords": [ "assets", "compression", "minification" ],
-    "homepage": "https://github.com/kriswallsmith/assetic",
+    "keywords": ["assets", "compression", "minification"],
+    "homepage": "https://github.com/assetic-php/assetic",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -10,6 +10,16 @@
             "name": "Kris Wallsmith",
             "email": "kris.wallsmith@gmail.com",
             "homepage": "http://kriswallsmith.net/"
+        },
+        {
+            "name": "Jack Wilkinson",
+            "email": "me@jackwilky.com",
+            "homepage": "https://jackwilky.com/"
+        },
+        {
+            "name": "Luke Towers",
+            "email": "octobercms@luketowers.ca",
+            "homepage": "https://luketowers.ca"
         }
     ],
     "require": {
@@ -40,6 +50,9 @@
         "ptachoire/cssembed": "Assetic provides the integration with phpcssembed to embed data uris",
         "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin",
         "patchwork/jsqueeze": "Assetic provides the integration with the JSqueeze JavaScript compressor"
+    },
+    "replace": {
+        "kriswallsmith/assetic": "*"
     },
     "autoload": {
         "psr-0": { "Assetic": "src/" },

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -113,7 +113,7 @@ class AsseticTokenParser extends \Twig_TokenParser
                 $attributes[$key] = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
             } else {
                 $token = $stream->getCurrent();
-                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getFilename());
+                throw new \Twig_Error_Syntax(sprintf('Unexpected token "%s" of value "%s"', \Twig_Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getSourceContext()->getName());
             }
         }
 


### PR DESCRIPTION
Removed old Twig_TokenStream::getFilename call in AsseticTokenParser which occurred when an unexpected punctuation exception was thrown.