### PR TITLE
Removed old Twig_TokenStream::getFilename call in AsseticTokenParser

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -111,7 +111,7 @@ class AsseticTokenParser extends AbstractTokenParser
                     Token::typeToEnglish($token->getType()),
                     $token->getValue()),
                     $token->getLine(),
-                    $stream->getFilename()
+                    $stream->getSourceContext()->getName()
                 );
             }
         }


### PR DESCRIPTION
Removed old Twig_TokenStream::getFilename call in AsseticTokenParser which occurred when an unexpected punctuation exception was thrown.

Resubmitting https://github.com/kriswallsmith/assetic/pull/845, as requested by @LukeTowers .

Original credits to @audoh