### PR TITLE
Update deps for symfony5 and make twig optional

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -20,13 +20,14 @@ a simplified tool set of php and javascript based utilities.
 ### New features
 
 * Support for `>=php 7.2`
-* Support for `symfony/process` 4
+* Support for `symfony/process` 4/5
 
 ### BC breaks
 
 - Minimum PHP version required is now PHP 7.2
 - Switching from `leafo/lessphp` to `wikimedia/less.php`
     - Due to this switch support has been dropped for `setPreserveComments` & `registerFunction` by the `LessphpFilter`.
+- `twig/twig` support is optional now, `twig/extensions` must be required in your requirements if you need it.
 
 # Filters Removed:
 - Roole | Roole was a language that compiles to CSS, the project is now dead and has been for at least 6 years | Use LESS \ SCSS instead

--- a/composer.json
+++ b/composer.json
@@ -23,28 +23,28 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/process": "~4.0",
-        "twig/extensions": "^1.5"
+        "symfony/process": "^4.0 || ^5.0"
     },
     "conflict": {
-        "twig/twig": "<1.27"
+        "twig/twig": "<1.27 || >=3.0"
     },
     "require-dev": {
         "wikimedia/less.php": "dev-master",
-        "scssphp/scssphp": "~1.0",
+        "scssphp/scssphp": "^1.0",
         "meenie/javascript-packer": "^1.1",
         "mrclay/minify": "<2.3",
-        "natxet/cssmin": "3.0.6",
-        "patchwork/jsqueeze": "~1.0|~2.0",
-        "phpunit/phpunit": "~8.0",
-        "psr/log": "~1.0",
-        "ptachoire/cssembed": "~1.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "twig/twig": "~2.11"
+        "natxet/cssmin": "^3.0.6",
+        "patchwork/jsqueeze": "^1.0 || ^2.0",
+        "phpunit/phpunit": "^8.0",
+        "psr/log": "^1.0",
+        "ptachoire/cssembed": "^1.0",
+        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "twig/twig": "^2.11",
+        "twig/extensions": "^1.5"
     },
     "suggest": {
         "wikimedia/less.php": "The Assetic\\Filter\\LessphpFilter requires wikimedia/less.php",
@@ -54,7 +54,7 @@
         "natxet/cssmin": "The Assetic\\Filter\\CssMinFilter requires natxet/cssmin",
         "patchwork/jsqueeze": "The Assetic\\Filter\\JSqueezeFilter requires patchwork/jsqueeze",
         "ptachoire/cssembed": "The Assetic\\Filter\\PhpCssEmbedFilter requires ptachoire/cssembed",
-        "twig/twig": "Assetic provides an integration with the Twig templating engine"
+        "twig/extensions": "Assetic provides an integration with the Twig templating engine"
     },
     "replace": {
         "kriswallsmith/assetic": "*"


### PR DESCRIPTION
- Updated `composer.json` to allow `symfony/process` 5.
- Made `twig/twig` optional
- Fixed some requirements contraints

Hope you can release it soon!

I think v2.0 should focus on maximize compatibility with the older library, maybe in 3.0 we can introduce support for twig 3.x.