### PR TITLE
Support Symfony 3.4 and Symfony ~4 as path for upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/process": "~4.0",
+        "symfony/process": "~3.4|~4.0",
         "twig/extensions": "^1.5"
     },
     "conflict": {


### PR DESCRIPTION
Hi! 

Thanks for your work here to let assetic live a bit longer. You've done any work to get the library run with symfony 4.0 but why miss out symfony 3.4 which is the same as 4.0 but with all the deprecations. I am on a path to upgrade to symfony 4.4. but the current version will be 3.4 for a while. So maybe it is possible to get this merged? 

Greetings & Thanks! 