### PR TITLE
Added support for the setOutputStyle option in ScssPhp

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 2.0/dev
+      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - develop
   pull_request:
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/process": "~3.4 || ~4.0 || ~5.0"
+        "symfony/process": "~3.4 || ~4.0 || ~5.0",
+        "symfony/deprecation-contracts": "^2.2.0"
     },
     "require-dev": {
         "wikimedia/less.php": "dev-master",
@@ -36,10 +37,10 @@
         "mrclay/minify": "<2.3",
         "natxet/cssmin": "^3.0.6",
         "patchwork/jsqueeze": "^1.0 || ^2.0",
-        "phpunit/phpunit": "~8.0 || ^9.4",
+        "phpunit/phpunit": "^8.5",
         "psr/log": "^1.0",
         "ptachoire/cssembed": "^1.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0",
+        "symfony/phpunit-bridge": "~3.4 || ~4.0 || ~5.0",
         "twig/twig": "^2.11",
         "twig/extensions": "^1.5"
     },
@@ -66,10 +67,5 @@
     },
     "config": {
         "bin-dir": "bin"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.4-dev"
-        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
-        <include>
-            <directory suffix=".php">./src/Assetic/</directory>
-        </include>
-    </coverage>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="./tests/bootstrap.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+>
     <testsuites>
         <testsuite name="Assetic Test Suite">
             <directory suffix="Test.php">./tests/Assetic/Test/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/Assetic/</directory>
+        </whitelist>
+    </filter>
+
     <php>
         <server name="NODE_PATH" value="./node_modules/"/>
     </php>

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -37,7 +37,13 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 
     public function setFormatter($formatter)
     {
-        @trigger_error('The method "setFormatter" is deprecated. Use "setOutputStyle" instead.', E_USER_DEPRECATED);
+        trigger_deprecation(
+            'scssphp/scssphp',
+            '1.4.0',
+            'The method "%s" is deprecated. Use "%s" instead.',
+            'setFormatter',
+            'setOutputStyle'
+        );
 
         $legacyFormatters = array(
             'scss_formatter' => 'ScssPhp\ScssPhp\Formatter\Expanded',

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -5,6 +5,7 @@ use Assetic\Contracts\Filter\DependencyExtractorInterface;
 use Assetic\Factory\AssetFactory;
 use Assetic\Util\CssUtils;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\OutputStyle;
 
 /**
  * Loads SCSS files using the PHP implementation of scss, scssphp.
@@ -21,6 +22,7 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
     private $importPaths = [];
     private $customFunctions = [];
     private $formatter;
+    private $outputStyle;
     private $variables = [];
 
     public function enableCompass($enable = true)
@@ -35,6 +37,8 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 
     public function setFormatter($formatter)
     {
+        @trigger_error('The method "setFormatter" is deprecated. Use "setOutputStyle" instead.', E_USER_DEPRECATED);
+
         $legacyFormatters = array(
             'scss_formatter' => 'ScssPhp\ScssPhp\Formatter\Expanded',
             'scss_formatter_nested' => 'ScssPhp\ScssPhp\Formatter\Nested',
@@ -49,6 +53,15 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
         }
 
         $this->formatter = $formatter;
+    }
+
+    public function setOutputStyle(string $outputStyle)
+    {
+        if (!in_array($outputStyle, [OutputStyle::EXPANDED, OutputStyle::COMPRESSED])) {
+            throw new \InvalidArgumentException('The output style must be compatible with `ScssPhp\ScssPhp\OutputStyle`');
+        }
+
+        $this->outputStyle = $outputStyle;
     }
 
     public function setVariables(array $variables)
@@ -98,6 +111,10 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 
         if ($this->formatter) {
             $sc->setFormatter($this->formatter);
+        }
+
+        if ($this->outputStyle) {
+            $sc->setOutputStyle($this->outputStyle);
         }
 
         if (!empty($this->variables)) {

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -5,6 +5,7 @@ use Assetic\Asset\FileAsset;
 use Assetic\Asset\StringAsset;
 use Assetic\Factory\AssetFactory;
 use Assetic\Filter\ScssphpFilter;
+use ScssPhp\ScssPhp\OutputStyle;
 
 /**
  * @group integration
@@ -22,7 +23,8 @@ class ScssphpFilterTest extends TestCase
     {
         $expected = <<<EOF
 .foo .bar {
-  width: 2; }
+  width: 2;
+}
 
 EOF;
 
@@ -38,10 +40,11 @@ EOF;
     {
         $expected = <<<EOF
 .foo {
-  color: blue; }
-
+  color: blue;
+}
 .foo {
-  color: red; }
+  color: red;
+}
 
 EOF;
 
@@ -93,6 +96,49 @@ EOF;
             $actual->getContent(),
             'scss_formatter can be changed'
         );
+    }
+
+    public function testSetOutputFormatExpanded()
+    {
+        $expected = <<<EOF
+.foo {
+  color: #fff;
+}
+
+EOF;
+
+        $actual = new StringAsset(".foo {\n  color: #fff;\n}");
+        $actual->load();
+
+        $filter = $this->getFilter();
+        $filter->setOutputStyle(OutputStyle::EXPANDED);
+        $filter->filterLoad($actual);
+
+        $this->assertEquals($expected, $actual->getContent());
+    }
+
+    public function testSetOutputFormatCompressed()
+    {
+        $actual = new StringAsset(".foo {\n  color: #fff;\n}");
+        $actual->load();
+
+        $filter = $this->getFilter();
+        $filter->setOutputStyle(OutputStyle::COMPRESSED);
+        $filter->filterLoad($actual);
+
+        $this->assertEquals('.foo{color:#fff}', $actual->getContent());
+    }
+
+    public function testSetOutputFormatInvalid()
+    {
+        $actual = new StringAsset(".foo {\n  color: #fff;\n}");
+        $actual->load();
+
+        $this->expectExceptionMessage('The output style must be compatible with `ScssPhp\ScssPhp\OutputStyle`');
+
+        $filter = $this->getFilter();
+        $filter->setOutputStyle('invalid');
+        $filter->filterLoad($actual);
     }
 
     /**

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -82,6 +82,9 @@ EOF;
         $this->assertStringContainsString('color: red', $asset->getContent(), 'custom function can be registered');
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetFormatter()
     {
         $actual = new StringAsset(".foo {\n  color: #fff;\n}");


### PR DESCRIPTION
It looks like the ScssPhp team are in the process of changing methods from `setFormatter` to `setOutputStyle`.

This PR adds support for `setOutputStyle` with new test cases and a deprecation message for `setFormatter`. Also update to some of the expected results in the test cases to match the new style used by ScssPhp.

Additionally I've changed the branch in the workflow config from `2.0/dev` -> `develop` as 2.0 has been released.