### PR TITLE
Allow access to the Reference name and the resolved asset

### DIFF
--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -32,6 +32,16 @@ class AssetReference implements AssetInterface
         }
     }
 
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getAsset()
+    {
+        return $this->resolve();
+    }
+
     public function ensureFilter(FilterInterface $filter)
     {
         $this->filters[] = $filter;

--- a/tests/Assetic/Test/Asset/AssetReferenceTest.php
+++ b/tests/Assetic/Test/Asset/AssetReferenceTest.php
@@ -53,6 +53,23 @@ class AssetReferenceTest extends TestCase
         );
     }
 
+    public function testGetName()
+    {
+        $this->assertEquals('foo', $this->ref->getName());
+    }
+
+    public function testGetAsset()
+    {
+        $asset = $this->getMockBuilder(AssetInterface::class)->getMock();
+
+        $this->am->expects($this->once())
+                 ->method('get')
+                 ->with('foo')
+                 ->will($this->returnValue($asset));
+
+        $this->assertEquals($asset, $this->ref->getAsset(), '->getAsset() returns the asset object');
+    }
+
     public function testLazyFilters()
     {
         $this->am->expects($this->never())->method('get');


### PR DESCRIPTION
While working on deduplication of assets in my own library, I found that I had to use a full copy of the `AssetReference` class. Since the `resolve` method and `name` properties are private, extending the class is not possible, and there are no methods available to retrieve just the `asset` or `name` of the Reference.

I'd like to add the following to the `AssetReference` class:

- `getName` returns the `name` of the reference
- `getAsset` returns the result of `resolve`