### PR TITLE
Fix the replacement of kriswallsmith/assetic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "twig/extensions": "Assetic provides an integration with the Twig templating engine"
     },
     "replace": {
-        "kriswallsmith/assetic": "*"
+        "kriswallsmith/assetic": "self.version"
     },
     "autoload": {
         "psr-0": { "Assetic": "src/" },


### PR DESCRIPTION
Version 2 of the new assetic package does not replace kriswallsmith/assetic 1.x (while the `*` constraint was telling it does) as there have been BC breaks.

another alternative is to use a conflict rule instead.