### PR TITLE
Fix usage of deprecated behaviours and methods in SCSS PHP filter

### DIFF
--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -104,7 +104,7 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
         $this->importPaths[] = $path;
     }
 
-    public function registerFunction($name, $callable, $argumentDeclaration = null)
+    public function registerFunction($name, $callable, array $argumentDeclaration = null)
     {
         $this->customFunctions[$name] = [
             'callable' => $callable,

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -6,6 +6,7 @@ use Assetic\Factory\AssetFactory;
 use Assetic\Util\CssUtils;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\OutputStyle;
+use ScssPhp\ScssPhp\ValueConverter;
 
 /**
  * Loads SCSS files using the PHP implementation of scss, scssphp.
@@ -81,7 +82,11 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
 
     public function setVariables(array $variables)
     {
-        $this->variables = $variables;
+        $this->variables = [];
+
+        foreach ($variables as $name => $value) {
+            $this->variables[$name] = ValueConverter::parseValue($value);
+        }
     }
 
     public function addVariable($variable)
@@ -99,9 +104,12 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
         $this->importPaths[] = $path;
     }
 
-    public function registerFunction($name, $callable)
+    public function registerFunction($name, $callable, $argumentDeclaration = null)
     {
-        $this->customFunctions[$name] = $callable;
+        $this->customFunctions[$name] = [
+            'callable' => $callable,
+            'argumentDeclaration' => $argumentDeclaration,
+        ];
     }
 
     public function filterLoad(AssetInterface $asset)
@@ -116,8 +124,8 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
             $sc->addImportPath($path);
         }
 
-        foreach ($this->customFunctions as $name => $callable) {
-            $sc->registerFunction($name, $callable);
+        foreach ($this->customFunctions as $name => $function) {
+            $sc->registerFunction($name, $function['callable'], $function['argumentDeclaration']);
         }
 
         if ($this->formatter) {
@@ -129,10 +137,10 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
         }
 
         if (!empty($this->variables)) {
-            $sc->setVariables($this->variables);
+            $sc->addVariables($this->variables);
         }
 
-        $asset->setContent($sc->compile($asset->getContent()));
+        $asset->setContent($sc->compileString($asset->getContent())->getCss());
     }
 
     public function getChildren(AssetFactory $factory, $content, $loadPath = null)

--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -6,6 +6,7 @@ use Assetic\Asset\StringAsset;
 use Assetic\Factory\AssetFactory;
 use Assetic\Filter\ScssphpFilter;
 use ScssPhp\ScssPhp\OutputStyle;
+use ScssPhp\ScssPhp\ValueConverter;
 
 /**
  * @group integration
@@ -75,8 +76,8 @@ EOF;
 
         $filter = $this->getFilter();
         $filter->registerFunction('bar', function () {
-            return 'red';
-        });
+            return ValueConverter::parseValue('red');
+        }, []);
         $filter->filterLoad($asset);
 
         $this->assertStringContainsString('color: red', $asset->getContent(), 'custom function can be registered');
@@ -188,13 +189,21 @@ EOF;
     public function testSetVariables()
     {
         $filter = $this->getFilter();
-        $filter->setVariables(array('color' => 'red'));
+        $filter->setVariables([
+            'color' => 'red',
+            'lineHeight' => 1.4,
+            'border' => '1px solid red',
+            'content' => '\'extra content\'',
+        ]);
 
-        $asset = new StringAsset("#test { color: \$color; }");
+        $asset = new StringAsset("#test { color: \$color; line-height: \$lineHeight; border: \$border; } #test::after { content: \$content; }");
         $asset->load();
         $filter->filterLoad($asset);
 
         $this->assertStringContainsString('color: red', $asset->getContent(), 'Variables can be added');
+        $this->assertStringContainsString('line-height: 1.4', $asset->getContent(), 'Variables can be added');
+        $this->assertStringContainsString('border: 1px solid red', $asset->getContent(), 'Variables can be added');
+        $this->assertStringContainsString('content: \'extra content\'', $asset->getContent(), 'Variables can be added');
     }
 
     // private


### PR DESCRIPTION
- Adds additional argument for registerFunction method to define argument declarations (fixes #11)
- Uses compileString() method for compilation as opposed to deprecated compile() method
- Uses addVariables() method for defining variables as opposed to deprecated setVariables() method
- Parses variables provided in the setVariables() filter method and converts to Scss values, avoiding the deprecated behavior of allowing raw variables

This should also hopefully fix the PHPUnit tests.