### PR TITLE
Fix aliases when used with preloader

### DIFF
--- a/src/aliasing.php
+++ b/src/aliasing.php
@@ -6,6 +6,12 @@
  * @author Jack Wilkinson <me@jackwilky.com>
  */
 
+if (interface_exists(Assetic\Asset\AssetInterface::class, false)) {
+    // Prevent error with preloading
+    // @see https://github.com/googleapis/google-api-php-client/issues/1976
+    return;
+}
+
 class_alias(
     Assetic\Contracts\Asset\AssetInterface::class,
     Assetic\Asset\AssetInterface::class

--- a/src/aliasing.php
+++ b/src/aliasing.php
@@ -6,9 +6,8 @@
  * @author Jack Wilkinson <me@jackwilky.com>
  */
 
+// Only run the aliasing once - Fixes preloading support on PHP 7.4+
 if (interface_exists(Assetic\Asset\AssetInterface::class, false)) {
-    // Prevent error with preloading
-    // @see https://github.com/googleapis/google-api-php-client/issues/1976
     return;
 }
 


### PR DESCRIPTION
The opcache preloader is not a fan of the class_alias:

```
nginx_1          | 2022/01/25 14:56:10 [error] 25#25: *119 FastCGI sent in stderr: "PHP message: PHP Warning:  Cannot declare interface Assetic\Asset\AssetInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 17PHP message: PHP Warning:  Cannot declare interface Assetic\Asset\AssetCollectionInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 22PHP message: PHP Warning:  Cannot declare interface Assetic\Cache\CacheInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 27PHP message: PHP Warning:  Cannot declare interface Assetic\Exception\Exception, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 32PHP message: PHP Warning:  Cannot declare interface Assetic\Factory\Loader\FormulaLoaderInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 37PHP message: PHP Warning:  Cannot declare interface Assetic\Resource\IteratorResourceInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 42PHP message: PHP Warning:  Cannot declare interface Assetic\Resource\ResourceInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 47PHP message: PHP Warning:  Cannot declare interface Assetic\Worker\WorkerInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 52PHP message: PHP Warning:  Cannot declare interface Assetic\Filter\DependencyExtractorInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 57PHP message: PHP Warning:  Cannot declare interface Assetic\Filter\FilterInterface, because the name is already in use in /www/foe/libs/external/assetic/framework/src/aliasing.php on line 62PHP message: PHP Warning:  Cannot dec
```