### PR TITLE
Added fix to test to ensure compatibility with scssphp 1.10.x

### DIFF
--- a/tests/Assetic/Test/Filter/ScssphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/ScssphpFilterTest.php
@@ -203,7 +203,7 @@ EOF;
         $this->assertStringContainsString('color: red', $asset->getContent(), 'Variables can be added');
         $this->assertStringContainsString('line-height: 1.4', $asset->getContent(), 'Variables can be added');
         $this->assertStringContainsString('border: 1px solid red', $asset->getContent(), 'Variables can be added');
-        $this->assertStringContainsString('content: \'extra content\'', $asset->getContent(), 'Variables can be added');
+        $this->assertStringContainsString('content: "extra content"', $asset->getContent(), 'Variables can be added');
     }
 
     // private


### PR DESCRIPTION
A change introduced `v1.10.0` for `scssphp/scssphp` ensured that strings were always quoted using double quotes, see [release notes](https://github.com/scssphp/scssphp/releases/tag/v1.10.0). This PR updates the tests to match.