### PR TITLE
Deprecation notices with PHP 8.1

### DIFF
--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -200,9 +200,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
         return $mtime;
     }
 
-    /**
-     * Returns an iterator for looping recursively over unique leaves.
-     */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \RecursiveIteratorIterator(new AssetCollectionFilterIterator(new AssetCollectionIterator($this, $this->clones)));

--- a/src/Assetic/Extension/Twig/ValueContainer.php
+++ b/src/Assetic/Extension/Twig/ValueContainer.php
@@ -45,6 +45,7 @@ class ValueContainer implements \ArrayAccess, \IteratorAggregate, \Countable
         throw new \BadMethodCallException('The ValueContainer is read-only.');
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $this->initialize();
@@ -52,6 +53,7 @@ class ValueContainer implements \ArrayAccess, \IteratorAggregate, \Countable
         return new \ArrayIterator($this->values);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         $this->initialize();

--- a/src/Assetic/Filter/FilterCollection.php
+++ b/src/Assetic/Filter/FilterCollection.php
@@ -60,11 +60,13 @@ class FilterCollection implements FilterInterface, \IteratorAggregate, \Countabl
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->filters);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->filters);

--- a/src/Assetic/Util/TraversableString.php
+++ b/src/Assetic/Util/TraversableString.php
@@ -16,11 +16,13 @@ class TraversableString implements \IteratorAggregate, \Countable
         $this->many = $many;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->many);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->many);


### PR DESCRIPTION
`
 Deprecated: Return type of Assetic\Filter\FilterCollection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/stack/src/www/vendor/assetic/framework/src/Assetic/Filter/FilterCollection.php on line 63
`

`
Deprecated: Return type of Assetic\Filter\FilterCollection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/stack/src/www/vendor/assetic/framework/src/Assetic/Filter/FilterCollection.php on line 69
`