### PR TITLE
Fix return type signature of getGlobals() in Twig extension

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticExtension.php
+++ b/src/Assetic/Extension/Twig/AsseticExtension.php
@@ -45,7 +45,7 @@ class AsseticExtension extends AbstractExtension implements GlobalsInterface
         return $functions;
     }
 
-    public function getGlobals()
+    public function getGlobals(): array
     {
         return array(
             'assetic' => array(


### PR DESCRIPTION
We need to declare the return type of `getGlobals` in `AsseticExtension` as `array` in order to be compatible with the same method in `GlobalsInterface` from the Twig library as of version 3.x.

Currently, Twig raises this error when trying to use this extension:
`Declaration of Assetic\Extension\Twig\AsseticExtension::getGlobals() must be compatible with Twig\Extension\GlobalsInterface::getGlobals(): array`

This is backwards-compatible with Twig 1 and 2, since they did not have a type hint for this method.