### PR TITLE
Create NoopAsset.php

### DIFF
--- a/src/Assetic/Asset/NoopAsset.php
+++ b/src/Assetic/Asset/NoopAsset.php
@@ -1,0 +1,19 @@
+<?php namespace Assetic\Asset;
+
+use Assetic\Asset\MockAsset;
+use Assetic\Asset\AssetInterface;
+use Assetic\Filter\FilterInterface;
+
+/**
+ * Class NoopAsset
+ *
+ * This class returns the content, unmodified, as a way to skip 
+ * or ignore an Asset during optimization.
+ */
+class NoopAsset extends MockAsset
+{
+    public function dump(FilterInterface $additionalFilter = null)
+    {
+      return $this->getContent();
+    }
+}

--- a/src/Assetic/Asset/NoopAsset.php
+++ b/src/Assetic/Asset/NoopAsset.php
@@ -7,13 +7,13 @@ use Assetic\Filter\FilterInterface;
 /**
  * Class NoopAsset
  *
- * This class returns the content, unmodified, as a way to skip 
+ * This class returns the content, unmodified, as a way to skip
  * or ignore an Asset during optimization.
  */
 class NoopAsset extends MockAsset
 {
     public function dump(FilterInterface $additionalFilter = null)
     {
-      return $this->getContent();
+        return $this->getContent();
     }
 }


### PR DESCRIPTION
The default implementation of `MockAsset` does not return anything within `dump`. We're extending `MockAsset` as a way to ignore an Asset from the optimization pipeline.