### PR TITLE
Re-added TwigFormulaLoader

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticFilterFunction.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterFunction.php
@@ -6,6 +6,12 @@ class AsseticFilterFunction
 {
     public static function make(AsseticExtension $extension, $name, $options = [])
     {
+        $options = array_merge($options, [
+            'needs_environment' => false,
+            'needs_context'     => false,
+            'node_class'        => AsseticFilterNode::class,
+        ]);
+
         return new TwigFunction($name, function ($input, array $options) use ($extension, $name) {
             return $extension->getFilterInvoker($name)->invoke($input, $options);
         }, $options);

--- a/src/Assetic/Extension/Twig/AsseticFilterNode.php
+++ b/src/Assetic/Extension/Twig/AsseticFilterNode.php
@@ -1,0 +1,19 @@
+<?php namespace Assetic\Extension\Twig;
+
+use Twig\Compiler;
+use Twig\Node\Expression\FunctionExpression;
+
+class AsseticFilterNode extends FunctionExpression
+{
+    protected function compileCallable(Compiler $compiler)
+    {
+        $compiler->raw(
+            sprintf(
+                '$this->env->getExtension(\'Assetic\\Extension\\Twig\\AsseticExtension\')->getFilterInvoker(\'%s\')->invoke',
+                $this->getAttribute('name')
+            )
+        );
+
+        $this->compileArguments($compiler);
+    }
+}

--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -1,0 +1,100 @@
+<?php namespace Assetic\Extension\Twig;
+
+use Assetic\Contracts\Factory\Loader\FormulaLoaderInterface;
+use Assetic\Contracts\Factory\Resource\ResourceInterface;
+use Psr\Log\LoggerInterface;
+use Twig\Environment;
+use Twig\Node\Node;
+use Twig\Source;
+
+/**
+ * Loads asset formulae from Twig templates.
+ *
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ */
+class TwigFormulaLoader implements FormulaLoaderInterface
+{
+    private $twig;
+    private $logger;
+
+    public function __construct(Environment $twig, LoggerInterface $logger = null)
+    {
+        $this->twig = $twig;
+        $this->logger = $logger;
+    }
+
+    public function load(ResourceInterface $resource)
+    {
+        try {
+            $tokens = $this->twig->tokenize(new Source($resource->getContent(), (string) $resource));
+            $nodes  = $this->twig->parse($tokens);
+        } catch (\Exception $e) {
+            if ($this->logger) {
+                $this->logger->error(sprintf('The template "%s" contains an error: %s', $resource, $e->getMessage()));
+            }
+
+            return [];
+        }
+
+        return $this->loadNode($nodes);
+    }
+
+    /**
+     * Loads assets from the supplied node.
+     *
+     * @param Node $node
+     *
+     * @return array An array of asset formulae indexed by name
+     */
+    private function loadNode(Node $node)
+    {
+        $formulae = [];
+
+        if ($node instanceof AsseticNode) {
+            $formulae[$node->getAttribute('name')] = [
+                $node->getAttribute('inputs'),
+                $node->getAttribute('filters'),
+                [
+                    'output'  => $node->getAttribute('asset')->getTargetPath(),
+                    'name'    => $node->getAttribute('name'),
+                    'debug'   => $node->getAttribute('debug'),
+                    'combine' => $node->getAttribute('combine'),
+                    'vars'    => $node->getAttribute('vars'),
+                ],
+            ];
+        } elseif ($node instanceof AsseticFilterNode) {
+            $name = $node->getAttribute('name');
+
+            $arguments = [];
+            foreach ($node->getNode('arguments') as $argument) {
+                $arguments[] = eval('return ' . $this->twig->compile($argument) . ';');
+            }
+
+            $invoker = $this->twig->getExtension(AsseticExtension::class)->getFilterInvoker($name);
+
+            $inputs  = isset($arguments[0]) ? (array) $arguments[0] : [];
+            $filters = $invoker->getFilters();
+            $options = array_replace($invoker->getOptions(), isset($arguments[1]) ? $arguments[1] : []);
+
+            if (!isset($options['name'])) {
+                $options['name'] = $invoker->getFactory()->generateAssetName($inputs, $filters, $options);
+            }
+
+            $formulae[$options['name']] = [$inputs, $filters, $options];
+        }
+
+        foreach ($node as $child) {
+            if ($child instanceof Node) {
+                $formulae += $this->loadNode($child);
+            }
+        }
+
+        if ($node->hasAttribute('embedded_templates')) {
+            foreach ($node->getAttribute('embedded_templates') as $child) {
+                $formulae += $this->loadNode($child);
+            }
+        }
+
+        return $formulae;
+    }
+}

--- a/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
+++ b/tests/Assetic/Test/Extension/Twig/TwigFormulaLoaderTest.php
@@ -1,0 +1,141 @@
+<?php namespace Assetic\Test\Extension\Twig;
+
+use Assetic\Contracts\Asset\AssetInterface;
+use Assetic\Contracts\Factory\Resource\ResourceInterface;
+use Assetic\Factory\AssetFactory;
+use Assetic\AssetManager;
+use Assetic\FilterManager;
+use Assetic\Extension\Twig\AsseticExtension;
+use Assetic\Extension\Twig\TwigFormulaLoader;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class TwigFormulaLoaderTest extends TestCase
+{
+    private $am;
+    private $fm;
+    /**
+     * @var TwigFormulaLoader
+     */
+    private $loader;
+
+    protected function setUp(): void
+    {
+        if (!class_exists('Twig\Environment')) {
+            $this->markTestSkipped('Twig is not installed.');
+        }
+
+        $this->am = $this->getMockBuilder(AssetManager::class)->getMock();
+        $this->fm = $this->getMockBuilder(FilterManager::class)->getMock();
+
+        $factory = new AssetFactory(__DIR__.'/templates');
+        $factory->setAssetManager($this->am);
+        $factory->setFilterManager($this->fm);
+
+        $twig = new Environment(new ArrayLoader([]));
+        $twig->addExtension(new AsseticExtension($factory, [
+            'some_func' => [
+                'filter' => 'some_filter',
+                'options' => ['output' => 'css/*.css'],
+            ],
+        ]));
+
+        $this->loader = new TwigFormulaLoader($twig);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->am = null;
+        $this->fm = null;
+    }
+
+    public function testMixture()
+    {
+        $asset = $this->getMockBuilder(AssetInterface::class)->getMock();
+
+        $expected = [
+            'mixture' => [
+                ['foo', 'foo/*', '@foo'],
+                [],
+                [
+                    'output'  => 'packed/mixture',
+                    'name'    => 'mixture',
+                    'debug'   => false,
+                    'combine' => null,
+                    'vars'    => [],
+                ],
+            ],
+        ];
+
+        $resource = $this->getMockBuilder(ResourceInterface::class)->getMock();
+        $resource->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue(file_get_contents(__DIR__.'/templates/mixture.twig')));
+        $this->am->expects($this->any())
+            ->method('get')
+            ->with('foo')
+            ->will($this->returnValue($asset));
+
+        $formulae = $this->loader->load($resource);
+        $this->assertEquals($expected, $formulae);
+    }
+
+    public function testFunction()
+    {
+        $expected = [
+            'my_asset' => [
+                ['path/to/asset'],
+                ['some_filter'],
+                [
+                    'output' => 'css/*.css',
+                    'name' => 'my_asset'
+                ],
+            ],
+        ];
+
+        $resource = $this->getMockBuilder(ResourceInterface::class)->getMock();
+        $resource->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue(file_get_contents(__DIR__.'/templates/function.twig')));
+
+        $formulae = $this->loader->load($resource);
+        $this->assertEquals($expected, $formulae);
+    }
+
+    public function testUnclosedTag()
+    {
+        $resource = $this->getMockBuilder(ResourceInterface::class)->getMock();
+        $resource->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue(file_get_contents(__DIR__.'/templates/unclosed_tag.twig')));
+
+        $formulae = $this->loader->load($resource);
+        $this->assertEquals([], $formulae);
+    }
+
+    public function testEmbeddedTemplate()
+    {
+        $expected = [
+            'image' => [
+                ['images/foo.png'],
+                [],
+                [
+                    'name'    => 'image',
+                    'debug'   => true,
+                    'vars'    => [],
+                    'output'  => 'images/foo.png',
+                    'combine' => false,
+                ],
+            ],
+        ];
+
+        $resource = $this->getMockBuilder(ResourceInterface::class)->getMock();
+        $resource->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue(file_get_contents(__DIR__.'/templates/embed.twig')));
+
+        $formulae = $this->loader->load($resource);
+        $this->assertEquals($expected, $formulae);
+    }
+}


### PR DESCRIPTION
When upgrading our projects we run into problems with the old Assetic repository, so firstly thanks for taking over the maintenance of the code. 

This PR addresses issue #15 where, when updating to the new version of Twig, a couple of extensions got removed in #https://github.com/assetic-php/assetic/commit/4e42ff8cb7814712c54c7edf6acc909729b97424 Those extensions are being re-added here together with passing tests.