### PR TITLE
Update wikimedia/less.php from 3.0 to 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,22 +23,22 @@
         }
     ],
     "require": {
-        "php": ">=7.4 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/process": "~3.4 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+        "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2.0"
     },
     "require-dev": {
-        "wikimedia/less.php": "^5.0",
-        "wikimedia/minify": "~2.2",
+        "wikimedia/less.php": "^3.0 || ^5.0",
+        "wikimedia/minify": "^2.2",
         "scssphp/scssphp": "^1.0",
         "meenie/javascript-packer": "^1.1",
         "phpunit/phpunit": "^9.5.8",
         "psr/log": "^1.0",
         "ptachoire/cssembed": "^1.0",
-        "symfony/phpunit-bridge": "~3.4 || ~4.0 || ~5.0 || ~6.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "twig/twig": "^2.11",
         "phpspec/prophecy-phpunit": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3 || ^8.0",
+        "php": ">=7.4 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
@@ -31,7 +31,7 @@
         "symfony/deprecation-contracts": "^2.2.0"
     },
     "require-dev": {
-        "wikimedia/less.php": "~3.0.0",
+        "wikimedia/less.php": "^5.0",
         "wikimedia/minify": "~2.2",
         "scssphp/scssphp": "^1.0",
         "meenie/javascript-packer": "^1.1",

--- a/tests/Assetic/Test/Filter/LessphpFilterTest.php
+++ b/tests/Assetic/Test/Filter/LessphpFilterTest.php
@@ -79,7 +79,7 @@ class LessphpFilterTest extends FilterTestCase
         $asset = new StringAsset('.foo { color: @bar }');
         $asset->load();
 
-        $this->filter->setPresets(array('bar' => 'green'));
+        $this->filter->setPresets(array('bar' => '#008000'));
         $this->filter->filterLoad($asset);
 
         $this->assertStringContainsString('#008000', $asset->getContent(), '->setPresets() to pass variables into lessphp filter');


### PR DESCRIPTION
https://github.com/wikimedia/less.php/blob/master/CHANGES.md

* 3.x: Fix bugs, add PHP 8.x support (fix warnings), improve performance.
* 4.0: Require PHP 7.4+.
* 4.x: Fix bugs, improve performance, add various missing Less.js features, full compliance with Less.js 2.5.3.
* 5.0:
  * Remove deprecated methods on Less_Parser, which Assetic doesn't use.
  * Fix breakage of slash in various new CSS features.
  * Change "math" default from "always" to "parens-division", same as upstream Less.js 4.x.
