### PR TITLE
Add Tailwind CSS Standalone CLI utility filter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,11 @@ jobs:
           npm install
 
       - name: Install Tailwind CSS Standalone CLI
-        run: |
-            wget -O tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
-            chmod +x tailwindcss
-            mv tailwindcss /usr/bin/
+        uses: supplypike/setup-bin@v4
+        with:
+            uri: 'https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.4/tailwindcss-linux-x64'
+            name: 'tailwindcss'
+            version: '3.4.4'
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,12 @@ jobs:
           sudo apt-get -y install jpegoptim libjpeg-progs optipng
           npm install
 
+      - name: Install Tailwind CSS Standalone CLI
+        run: |
+            wget -O tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
+            chmod +x tailwindcss
+            mv tailwindcss /usr/bin/
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The core provides the following filters in the `Assetic\Filter` namespace:
  * `SeparatorFilter`: inserts a separator between assets to prevent merge failures
  * `StylesheetMinifyFilter`: compresses stylesheet CSS files
  * `StylusFilter`: parses STYL into CSS
+ * `TailwindCssFilter`: builds a Tailwind CSS stylesheet using the Tailwind CSS standalone CLI utility
  * `TypeScriptFilter`: parses TypeScript into Javascript
  * `UglifyCssFilter`: minifies CSS
  * `UglifyJs2Filter`: minifies Javascript

--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -17,9 +17,9 @@ abstract class BaseProcessFilter extends BaseFilter
     protected $binaryPath;
 
     /**
-     * Defines the working directory for the process.
+     * @var string|null Defines the working directory for the process.
      */
-    protected ?string $workingDirectory = null;
+    protected $workingDirectory = null;
 
     /**
      * @var boolean Flag to indicate that the process will output the result to the input file

--- a/src/Assetic/Filter/BaseProcessFilter.php
+++ b/src/Assetic/Filter/BaseProcessFilter.php
@@ -17,6 +17,11 @@ abstract class BaseProcessFilter extends BaseFilter
     protected $binaryPath;
 
     /**
+     * Defines the working directory for the process.
+     */
+    protected ?string $workingDirectory = null;
+
+    /**
      * @var boolean Flag to indicate that the process will output the result to the input file
      */
     protected $useInputAsOutput = false;
@@ -76,6 +81,25 @@ abstract class BaseProcessFilter extends BaseFilter
     }
 
     /**
+     * Sets the binary path for the process.
+     */
+    public function setBinaryPath(string $binaryPath): void
+    {
+        $this->binaryPath = $binaryPath;
+    }
+
+    /**
+     * Sets the working directory for the process.
+     *
+     * Some processes may require a specified working directory to function correctly, ie. locating configurations,
+     * assets, etc.
+     */
+    public function setWorkingDirectory(?string $workingDirectory = null): void
+    {
+        $this->workingDirectory = $workingDirectory;
+    }
+
+    /**
      * Creates a new process.
      *
      * @param array $arguments An optional array of arguments
@@ -83,7 +107,7 @@ abstract class BaseProcessFilter extends BaseFilter
      */
     protected function createProcess(array $arguments = [])
     {
-        $process = new Process($arguments);
+        $process = new Process($arguments, $this->workingDirectory);
 
         if (null !== $this->timeout) {
             $process->setTimeout($this->timeout);

--- a/src/Assetic/Filter/TailwindCssFilter.php
+++ b/src/Assetic/Filter/TailwindCssFilter.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Assetic\Filter;
+
+use Assetic\Contracts\Asset\AssetInterface;
+
+/**
+ * Tailwind CSS filter.
+ *
+ * Compiles Tailwind CSS into standard CSS, using the standalone Tailwind CSS CLI tool.
+ *
+ * @author Ben Thomson <git@alfreido.com>
+ */
+class TailwindCssFilter extends BaseProcessFilter
+{
+    /**
+     * @var string Path to the binary for this process based filter
+     */
+    protected $binaryPath = '/usr/bin/tailwindcss';
+
+    /**
+     * Path to the Tailwind configuration file.
+     */
+    protected ?string $configPath = null;
+
+    /**
+     * Is minification enabled?
+     */
+    protected bool $minify = false;
+
+    /**
+     * Is autoprefixing enabled?
+     */
+    protected bool $autoprefix = true;
+
+    /**
+     * Sets the path for the configuration file.
+     */
+    public function setConfigPath(string $configPath): void
+    {
+        $this->configPath = $configPath;
+    }
+
+    /**
+     * Enable minification.
+     */
+    public function minify(): void
+    {
+        $this->minify = true;
+    }
+
+    /**
+     * Disable autoprefixer.
+     */
+    public function withoutAutoprefixing(): void
+    {
+        $this->autoprefix = false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function filterLoad(AssetInterface $asset)
+    {
+        $args = [
+            '--input',
+            '{INPUT}',
+            '--output',
+            '{OUTPUT}'
+        ];
+
+        if (!is_null($this->configPath)) {
+            $args[] = '--config';
+            $args[] = $this->configPath;
+        }
+
+        if ($this->minify) {
+            $args[] = '--minify';
+        }
+
+        if (!$this->autoprefix) {
+            $args[] = '--no-autoprefixer';
+        }
+
+        $result = $this->runProcess($asset->getContent(), $args);
+        $asset->setContent($result);
+    }
+}

--- a/src/Assetic/Filter/TailwindCssFilter.php
+++ b/src/Assetic/Filter/TailwindCssFilter.php
@@ -19,19 +19,19 @@ class TailwindCssFilter extends BaseProcessFilter
     protected $binaryPath = '/usr/bin/tailwindcss';
 
     /**
-     * Path to the Tailwind configuration file.
+     * @var string|null Path to the Tailwind configuration file.
      */
-    protected ?string $configPath = null;
+    protected $configPath = null;
 
     /**
-     * Is minification enabled?
+     * @var bool Is minification enabled?
      */
-    protected bool $minify = false;
+    protected $minify = false;
 
     /**
-     * Is autoprefixing enabled?
+     * @var bool Is autoprefixing enabled?
      */
-    protected bool $autoprefix = true;
+    protected $autoprefix = true;
 
     /**
      * Sets the path for the configuration file.

--- a/tests/Assetic/Test/Filter/TailwindCssFilterTest.php
+++ b/tests/Assetic/Test/Filter/TailwindCssFilterTest.php
@@ -10,7 +10,8 @@ use Assetic\Filter\TailwindCssFilter;
  */
 class TailwindCssFilterTest extends FilterTestCase
 {
-    private ?TailwindCssFilter $filter;
+    /** @var TailwindCssFilter|null */
+    private $filter;
 
     protected function setUp(): void
     {

--- a/tests/Assetic/Test/Filter/TailwindCssFilterTest.php
+++ b/tests/Assetic/Test/Filter/TailwindCssFilterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Assetic\Test\Filter;
+
+use Assetic\Asset\FileAsset;
+use Assetic\Filter\TailwindCssFilter;
+
+/**
+ * @group integration
+ */
+class TailwindCssFilterTest extends FilterTestCase
+{
+    private ?TailwindCssFilter $filter;
+
+    protected function setUp(): void
+    {
+        $tailwindCssBin = $this->findExecutable('tailwindcss', 'TAILWINDCSS_BIN');
+
+        if (!$tailwindCssBin) {
+            $this->markTestSkipped('Unable to find `tailwindcss` executable.');
+        }
+
+        $this->filter = new TailwindCssFilter($tailwindCssBin);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filter = null;
+    }
+
+    public function testFilterLoad()
+    {
+        $fileAsset = new FileAsset(__DIR__ . '/fixtures/tailwindcss/css/style.css');
+        $fileAsset->load();
+
+        $this->filter->setConfigPath(__DIR__ . '/fixtures/tailwindcss/tailwind.config.js');
+        $this->filter->setWorkingDirectory(__DIR__ . '/fixtures/tailwindcss');
+        $this->filter->filterLoad($fileAsset);
+        $contents = $fileAsset->getContent();
+
+        // Detect boilerplate TailwindCSS styling
+        $expected = <<<'STYLE'
+            ::backdrop {
+              --tw-border-spacing-x: 0;
+              --tw-border-spacing-y: 0;
+              --tw-translate-x: 0;
+              --tw-translate-y: 0;
+            STYLE;
+
+        $this->assertStringContainsString($expected, $contents);
+
+        // Detect class defined in HTML
+        $expected = <<<'STYLE'
+            .text-gray-800 {
+              --tw-text-opacity: 1;
+              color: rgb(31 41 55 / var(--tw-text-opacity));
+            }
+            STYLE;
+
+        $this->assertStringContainsString($expected, $contents);
+    }
+
+    public function testFilterLoadWithMinification()
+    {
+        $fileAsset = new FileAsset(__DIR__ . '/fixtures/tailwindcss/css/style.css');
+        $fileAsset->load();
+
+        $this->filter->setConfigPath(__DIR__ . '/fixtures/tailwindcss/tailwind.config.js');
+        $this->filter->setWorkingDirectory(__DIR__ . '/fixtures/tailwindcss');
+        $this->filter->minify();
+        $this->filter->filterLoad($fileAsset);
+        $contents = $fileAsset->getContent();
+
+        // Detect boilerplate TailwindCSS styling
+        $expected = <<<'STYLE'
+            *,::backdrop,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;
+            STYLE;
+
+        $this->assertStringContainsString($expected, $contents);
+
+        // Detect class defined in HTML
+        $expected = <<<'STYLE'
+            .text-gray-800{--tw-text-opacity:1;color:rgb(31 41 55/var(--tw-text-opacity))}
+            STYLE;
+
+        $this->assertStringContainsString($expected, $contents);
+    }
+}

--- a/tests/Assetic/Test/Filter/fixtures/tailwindcss/css/style.css
+++ b/tests/Assetic/Test/Filter/fixtures/tailwindcss/css/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tests/Assetic/Test/Filter/fixtures/tailwindcss/html/index.html
+++ b/tests/Assetic/Test/Filter/fixtures/tailwindcss/html/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tailwind CSS test</title>
+</head>
+<body class="antialiased bg-white text-gray-800">
+    <div class="flex flex-row gap-10">
+        <div class="bg-red text-white p-4">Red</div>
+        <div class="bg-green text-white p-4">Green</div>
+        <div class="bg-blue text-white p-4">Blue</div>
+    </div>
+</body>
+</html>

--- a/tests/Assetic/Test/Filter/fixtures/tailwindcss/tailwind.config.js
+++ b/tests/Assetic/Test/Filter/fixtures/tailwindcss/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+    content: ["./html/**/*.html"],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+  }

--- a/tests/Assetic/Test/Filter/fixtures/tailwindcss/test.css
+++ b/tests/Assetic/Test/Filter/fixtures/tailwindcss/test.css
@@ -1,0 +1,591 @@
+/*
+! tailwindcss v3.4.4 | MIT License | https://tailwindcss.com
+*/
+
+/*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: #e5e7eb;
+  /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
+*/
+
+html,
+:host {
+  line-height: 1.5;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  -moz-tab-size: 4;
+  /* 3 */
+  -o-tab-size: 4;
+     tab-size: 4;
+  /* 3 */
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  /* 4 */
+  font-feature-settings: normal;
+  /* 5 */
+  font-variation-settings: normal;
+  /* 6 */
+  -webkit-tap-highlight-color: transparent;
+  /* 7 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0;
+  /* 1 */
+  line-height: inherit;
+  /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  border-top-width: 1px;
+  /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  /* 1 */
+  font-feature-settings: normal;
+  /* 2 */
+  font-variation-settings: normal;
+  /* 3 */
+  font-size: 1em;
+  /* 4 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+  border-collapse: collapse;
+  /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-feature-settings: inherit;
+  /* 1 */
+  font-variation-settings: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  font-weight: inherit;
+  /* 1 */
+  line-height: inherit;
+  /* 1 */
+  letter-spacing: inherit;
+  /* 1 */
+  color: inherit;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+  padding: 0;
+  /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
+  -webkit-appearance: button;
+  /* 1 */
+  background-color: transparent;
+  /* 2 */
+  background-image: none;
+  /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Reset default styling for dialogs.
+*/
+
+dialog {
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+
+[hidden] {
+  display: none;
+}
+
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.gap-10 {
+  gap: 2.5rem;
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}


### PR DESCRIPTION
This PR adds support for using the [Tailwind CSS standalone CLI utility](https://tailwindcss.com/blog/standalone-cli) as a filter in Assetic, allowing the building of Tailwind CSS through Assetic.

To allow this filter to work correctly, some adjustments have been made to the base Process filter class:

- The binary path of the filter can be specified on the fly now using the `setBinaryPath` method.
- The base directory that the process will run in can also be changed using the `setWorkingDirectory` method. This allows the Tailwind CSS utility to run within a certain folder, allowing the config to be determined automatically and for content files to be correctly found and parsed.