### PR TITLE
Allow "symfony/deprecation-contracts": "^2.2.0|^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/deprecation-contracts": "^2.2.0"
+        "symfony/deprecation-contracts": "^2.2.0 || ^3.0"
     },
     "require-dev": {
         "wikimedia/less.php": "^3.0 || ^5.0",


### PR DESCRIPTION
They have added type hinting for `trigger_deprecation` parameters. The way it use it is compatible with this version.

https://github.com/symfony/deprecation-contracts/compare/v2.5.2...v3.5.0