### PR TITLE
Improve PHP 8.4 support

### DIFF
--- a/src/Assetic/Asset/AssetCache.php
+++ b/src/Assetic/Asset/AssetCache.php
@@ -38,7 +38,7 @@ class AssetCache implements AssetInterface
         $this->asset->clearFilters();
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         $cacheKey = self::getCacheKey($this->asset, $additionalFilter, 'load');
         if ($this->cache->has($cacheKey)) {
@@ -51,7 +51,7 @@ class AssetCache implements AssetInterface
         $this->cache->set($cacheKey, $this->asset->getContent());
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
         $cacheKey = self::getCacheKey($this->asset, $additionalFilter, 'dump');
         if ($this->cache->has($cacheKey)) {
@@ -130,13 +130,13 @@ class AssetCache implements AssetInterface
      *  * last modified
      *  * filters
      *
-     * @param AssetInterface  $asset            The asset
-     * @param FilterInterface $additionalFilter Any additional filter being applied
-     * @param string          $salt             Salt for the key
+     * @param AssetInterface   $asset            The asset
+     * @param ?FilterInterface $additionalFilter Any additional filter being applied
+     * @param string           $salt             Salt for the key
      *
      * @return string A key for identifying the current asset
      */
-    private static function getCacheKey(AssetInterface $asset, FilterInterface $additionalFilter = null, $salt = '')
+    private static function getCacheKey(AssetInterface $asset, ?FilterInterface $additionalFilter = null, $salt = '')
     {
         if ($additionalFilter) {
             $asset = clone $asset;

--- a/src/Assetic/Asset/AssetCollection.php
+++ b/src/Assetic/Asset/AssetCollection.php
@@ -125,7 +125,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
         $this->clones = new \SplObjectStorage();
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         // loop through leaves and load each asset
         $parts = [];
@@ -137,7 +137,7 @@ class AssetCollection implements \IteratorAggregate, AssetCollectionInterface
         $this->content = implode("\n", $parts);
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
         // loop through leaves and dump each asset
         $parts = [];

--- a/src/Assetic/Asset/AssetReference.php
+++ b/src/Assetic/Asset/AssetReference.php
@@ -52,14 +52,14 @@ class AssetReference implements AssetInterface
         $this->callAsset(__FUNCTION__);
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         $this->flushFilters();
 
         return $this->callAsset(__FUNCTION__, array($additionalFilter));
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
         $this->flushFilters();
 

--- a/src/Assetic/Asset/BaseAsset.php
+++ b/src/Assetic/Asset/BaseAsset.php
@@ -70,10 +70,10 @@ abstract class BaseAsset implements AssetInterface
     /**
      * Encapsulates asset loading logic.
      *
-     * @param string          $content          The asset content
-     * @param FilterInterface $additionalFilter An additional filter
+     * @param string           $content          The asset content
+     * @param ?FilterInterface $additionalFilter An additional filter
      */
-    protected function doLoad($content, FilterInterface $additionalFilter = null)
+    protected function doLoad($content, ?FilterInterface $additionalFilter = null)
     {
         $filter = clone $this->filters;
         if ($additionalFilter) {
@@ -89,7 +89,7 @@ abstract class BaseAsset implements AssetInterface
         $this->loaded = true;
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
         if (!$this->loaded) {
             $this->load();

--- a/src/Assetic/Asset/FileAsset.php
+++ b/src/Assetic/Asset/FileAsset.php
@@ -45,7 +45,7 @@ class FileAsset extends BaseAsset
         parent::__construct($filters, $sourceRoot, $sourcePath, $vars);
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         $source = VarUtils::resolve($this->source, $this->getVars(), $this->getValues());
 

--- a/src/Assetic/Asset/GlobAsset.php
+++ b/src/Assetic/Asset/GlobAsset.php
@@ -41,7 +41,7 @@ class GlobAsset extends AssetCollection
         return parent::all();
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         if (!$this->initialized) {
             $this->initialize();
@@ -50,7 +50,7 @@ class GlobAsset extends AssetCollection
         parent::load($additionalFilter);
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
         if (!$this->initialized) {
             $this->initialize();

--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -42,7 +42,7 @@ class HttpAsset extends BaseAsset
         parent::__construct($filters, $scheme . '://' . $host, $path, $vars);
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         $content = @file_get_contents(
             VarUtils::resolve($this->sourceUrl, $this->getVars(), $this->getValues())

--- a/src/Assetic/Asset/MockAsset.php
+++ b/src/Assetic/Asset/MockAsset.php
@@ -32,11 +32,11 @@ class MockAsset implements AssetInterface
     {
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
     }
 
-    public function dump(FilterInterface $additionalFilter = null)
+    public function dump(?FilterInterface $additionalFilter = null)
     {
     }
 

--- a/src/Assetic/Asset/StringAsset.php
+++ b/src/Assetic/Asset/StringAsset.php
@@ -29,7 +29,7 @@ class StringAsset extends BaseAsset
         parent::__construct($filters, $sourceRoot, $sourcePath);
     }
 
-    public function load(FilterInterface $additionalFilter = null)
+    public function load(?FilterInterface $additionalFilter = null)
     {
         $this->doLoad($this->string, $additionalFilter);
     }

--- a/src/Assetic/Contracts/Asset/AssetInterface.php
+++ b/src/Assetic/Contracts/Asset/AssetInterface.php
@@ -35,9 +35,9 @@ interface AssetInterface
      *
      * You may provide an additional filter to apply during load.
      *
-     * @param FilterInterface $additionalFilter An additional filter
+     * @param ?FilterInterface $additionalFilter An additional filter
      */
-    public function load(FilterInterface $additionalFilter = null);
+    public function load(?FilterInterface $additionalFilter = null);
 
     /**
      * Applies dump filters and returns the asset as a string.
@@ -49,11 +49,11 @@ interface AssetInterface
      * If the current asset has not been loaded yet, it should be
      * automatically loaded at this time.
      *
-     * @param FilterInterface $additionalFilter An additional filter
+     * @param ?FilterInterface $additionalFilter An additional filter
      *
      * @return string The filtered content of the current asset
      */
-    public function dump(FilterInterface $additionalFilter = null);
+    public function dump(?FilterInterface $additionalFilter = null);
 
     /**
      * Returns the loaded content of the current asset.

--- a/src/Assetic/Exception/FilterException.php
+++ b/src/Assetic/Exception/FilterException.php
@@ -32,7 +32,7 @@ class FilterException extends \RuntimeException implements Exception
         return new self($message);
     }
 
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct($message, $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Assetic/Extension/Twig/AsseticExtension.php
+++ b/src/Assetic/Extension/Twig/AsseticExtension.php
@@ -13,7 +13,7 @@ class AsseticExtension extends AbstractExtension implements GlobalsInterface
     protected $functions;
     protected $valueSupplier;
 
-    public function __construct(AssetFactory $factory, $functions = [], ValueSupplierInterface $valueSupplier = null)
+    public function __construct(AssetFactory $factory, $functions = [], ?ValueSupplierInterface $valueSupplier = null)
     {
         $this->factory = $factory;
         $this->functions = [];

--- a/src/Assetic/Extension/Twig/TwigFormulaLoader.php
+++ b/src/Assetic/Extension/Twig/TwigFormulaLoader.php
@@ -19,7 +19,7 @@ class TwigFormulaLoader implements FormulaLoaderInterface
     private $twig;
     private $logger;
 
-    public function __construct(Environment $twig, LoggerInterface $logger = null)
+    public function __construct(Environment $twig, ?LoggerInterface $logger = null)
     {
         $this->twig = $twig;
         $this->logger = $logger;

--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -20,9 +20,9 @@ class CssImportFilter extends BaseCssFilter implements DependencyExtractorInterf
     /**
      * Constructor.
      *
-     * @param FilterInterface $importFilter Filter for each imported asset
+     * @param ?FilterInterface $importFilter Filter for each imported asset
      */
-    public function __construct(FilterInterface $importFilter = null)
+    public function __construct(?FilterInterface $importFilter = null)
     {
         $this->importFilter = $importFilter ?: new CssRewriteFilter();
     }

--- a/src/Assetic/Filter/ScssphpFilter.php
+++ b/src/Assetic/Filter/ScssphpFilter.php
@@ -106,7 +106,7 @@ class ScssphpFilter extends BaseFilter implements DependencyExtractorInterface
         $this->importPaths[] = $path;
     }
 
-    public function registerFunction($name, $callable, array $argumentDeclaration = null)
+    public function registerFunction($name, $callable, ?array $argumentDeclaration = null)
     {
         $this->customFunctions[$name] = [
             'callable' => $callable,

--- a/src/Assetic/Filter/UglifyJs3Filter.php
+++ b/src/Assetic/Filter/UglifyJs3Filter.php
@@ -25,8 +25,8 @@ class UglifyJs3Filter extends BaseNodeFilter
     private $defines;
 
     /**
-     * @param string $uglifyjsBin Absolute path to the uglifyjs executable
-     * @param string $nodeBin     Absolute path to the folder containg node.js executable
+     * @param string  $uglifyjsBin Absolute path to the uglifyjs executable
+     * @param ?string $nodeBin     Absolute path to the folder containing node.js executable
      */
     public function __construct($uglifyjsBin = '/usr/bin/uglifyjs', $nodeBin = null)
     {

--- a/tests/Assetic/Test/Filter/UglifyJs3FilterTest.php
+++ b/tests/Assetic/Test/Filter/UglifyJs3FilterTest.php
@@ -68,7 +68,7 @@ JS;
 /**
  * Copyright
  */
-"undefined"==typeof FOO&&(FOO=1),function(){new Array(FOO,2,3,4);var bar=Array(a,b,c),var2=(new Array(5),new Array(a));function bar(foo){var2.push(foo)}bar("abc123")}();
+"undefined"==typeof FOO&&(FOO=1),(()=>{new Array(FOO,2,3,4);var bar=Array(a,b,c),var2=(new Array(5),new Array(a));function bar(foo){var2.push(foo)}bar("abc123")})();
 JS;
         $this->assertEquals($expected, $this->asset->getContent());
     }
@@ -83,7 +83,7 @@ JS;
 /**
  * Copyright
  */
-!function(){new Array(2,2,3,4);var bar=Array(a,b,c),var2=(new Array(5),new Array(a));function bar(foo){var2.push(foo)}bar("abc123")}();
+(()=>{new Array(2,2,3,4);var bar=Array(a,b,c),var2=(new Array(5),new Array(a));function bar(foo){var2.push(foo)}bar("abc123")})();
 JS;
         $this->assertEquals($expected, $this->asset->getContent());
     }
@@ -98,7 +98,7 @@ JS;
 /**
  * Copyright
  */
-"undefined"==typeof DEBUG&&(DEBUG=!0),"undefined"==typeof FOO&&(FOO=1),function(){FOO;var bar=[a,b,c],var2=Array(a);function bar(foo){var2.push(foo)}DEBUG&&console.log("hellow world"),bar("abc123")}();
+"undefined"==typeof DEBUG&&(DEBUG=!0),"undefined"==typeof FOO&&(FOO=1),(()=>{FOO;var bar=[a,b,c],var2=Array(a);function bar(foo){var2.push(foo)}DEBUG&&console.log("hellow world"),bar("abc123")})();
 JS;
         $this->assertEquals($expected, $this->asset->getContent());
     }


### PR DESCRIPTION
## What / Why
Fix implicitly nullable parameter declarations, which are [deprecated in PHP 8.4](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated).