### PR TITLE
fix(asset): migrate from $http_response_header to http_get_last_response_headers()

### DIFF
--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -58,7 +58,12 @@ class HttpAsset extends BaseAsset
     public function getLastModified()
     {
         if (false !== @file_get_contents($this->sourceUrl, false, stream_context_create(array('http' => array('method' => 'HEAD'))))) {
-            foreach ($http_response_header as $header) {
+            // TODO: $http_response_header deprecated since PHP 8.5
+            //       Remove when min PHP >= 8.4 and use http_get_last_response_headers() directly
+            $headers = function_exists('http_get_last_response_headers')
+                ? http_get_last_response_headers()
+                : $http_response_header;
+            foreach ($headers as $header) {
                 if (0 === stripos($header, 'Last-Modified: ')) {
                     list(, $mtime) = explode(':', $header, 2);
 


### PR DESCRIPTION
Use http_get_last_response_headers() when available and keep $http_response_header fallback for PHP < 8.4. Comment marks the shim for removal when minimum PHP >= 8.4.