### PR TITLE
fix: resolve PHP 8.4/8.5 deprecations in HttpAsset and BasePhpFormulaLoader

### DIFF
--- a/src/Assetic/Asset/HttpAsset.php
+++ b/src/Assetic/Asset/HttpAsset.php
@@ -58,11 +58,13 @@ class HttpAsset extends BaseAsset
     public function getLastModified()
     {
         if (false !== @file_get_contents($this->sourceUrl, false, stream_context_create(array('http' => array('method' => 'HEAD'))))) {
-            // TODO: $http_response_header deprecated since PHP 8.5
-            //       Remove when min PHP >= 8.4 and use http_get_last_response_headers() directly
+            // http_get_last_response_headers() was added in PHP 8.4; older versions fall back
+            // to the predefined $http_response_header. The `?? []` coalescing read avoids the
+            // PHP 8.5 deprecation of that variable: a bare read is flagged at compile time,
+            // a coalescing read is not. Drop the fallback once the minimum PHP version is >= 8.4.
             $headers = function_exists('http_get_last_response_headers')
                 ? http_get_last_response_headers()
-                : $http_response_header;
+                : ($http_response_header ?? []);
             foreach ($headers as $header) {
                 if (0 === stripos($header, 'Last-Modified: ')) {
                     list(, $mtime) = explode(':', $header, 2);

--- a/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
+++ b/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
@@ -106,7 +106,7 @@ abstract class BasePhpFormulaLoader implements FormulaLoaderInterface
             'echo serialize($_call);',
         )));
         $output = shell_exec('php ' . escapeshellarg($tmp));
-        $args = is_string($output) ? unserialize($output) : array();
+        $args = is_string($output) ? unserialize($output) : [];
         unlink($tmp);
 
         $inputs  = isset($args[0]) ? self::argumentToArray($args[0]) : [];

--- a/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
+++ b/src/Assetic/Factory/Loader/BasePhpFormulaLoader.php
@@ -105,7 +105,8 @@ abstract class BasePhpFormulaLoader implements FormulaLoaderInterface
             $call,
             'echo serialize($_call);',
         )));
-        $args = unserialize(shell_exec('php ' . escapeshellarg($tmp)));
+        $output = shell_exec('php ' . escapeshellarg($tmp));
+        $args = is_string($output) ? unserialize($output) : array();
         unlink($tmp);
 
         $inputs  = isset($args[0]) ? self::argumentToArray($args[0]) : [];

--- a/src/Assetic/Filter/CssImportFilter.php
+++ b/src/Assetic/Filter/CssImportFilter.php
@@ -7,6 +7,7 @@ use Assetic\Asset\FileAsset;
 use Assetic\Asset\HttpAsset;
 use Assetic\Factory\AssetFactory;
 use Assetic\Contracts\Filter\DependencyExtractorInterface;
+use Assetic\Contracts\Filter\FilterInterface;
 
 /**
  * Inlines imported stylesheets.


### PR DESCRIPTION
## Summary

A full PHPUnit run under **PHP 8.4.14** and **PHP 8.5.5** with `error_reporting=-1` surfaced two deprecations originating in the library's own `src/` (everything else came from `twig`/`scssphp` in `vendor/`). This PR fixes both, plus one latent type-hint bug found along the way.

### 1. `HttpAsset::getLastModified()` — `$http_response_header` deprecated (PHP 8.5)

The predefined locally scoped `$http_response_header` variable is deprecated in 8.5. The existing `function_exists('http_get_last_response_headers')` shim does **not** suppress it: the notice is emitted at **compile time** from the bare variable read — verified with `php -l`, which executes nothing yet still emits it — so a runtime guard can never silence it.

Reading it through the null-coalescing operator (`$http_response_header ?? []`) compiles to a non-deprecated fetch, so the pre-8.4 fallback keeps working while 8.5 emits nothing. `?? []` (not `?? null`) keeps the subsequent `foreach` safe. `composer.json` still pins `php: ^7.3 || ^8.0`, so the legacy branch can't be dropped outright yet — the comment notes when it can.

### 2. `BasePhpFormulaLoader::processCall()` — `null` to `unserialize()` (PHP 8.4 & 8.5)

`shell_exec()` returns `string|false|null`; passing `null` to `unserialize()`'s non-nullable `string` parameter is deprecated in 8.4+. Guarded with `is_string()`. The `array()` fallback is behaviour-identical to the previous `unserialize(false) === false` path (the downstream `isset($args[0..2])` checks read `false` on an empty array).

### 3. `CssImportFilter` — missing `use` (latent, any PHP version)

The constructor's `?FilterInterface` hint resolved to a non-existent `Assetic\Filter\FilterInterface` instead of the real `Assetic\Contracts\Filter\FilterInterface` (no matching import) — a latent `Error` whenever a non-null filter is passed. Added the missing `use`.