### PR TITLE
feat: support Twig 3 alongside Twig 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "psr/log": "^1.0",
         "ptachoire/cssembed": "^1.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-        "twig/twig": "^2.11",
+        "twig/twig": "^2.11 || ^3.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {

--- a/src/Assetic/Extension/Twig/AsseticNode.php
+++ b/src/Assetic/Extension/Twig/AsseticNode.php
@@ -3,9 +3,12 @@
 namespace Assetic\Extension\Twig;
 
 use Assetic\Contracts\Asset\AssetInterface;
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
+use Twig\Environment;
 use Twig\Node\Node;
 
+#[YieldReady]
 class AsseticNode extends Node
 {
     /**
@@ -36,7 +39,14 @@ class AsseticNode extends Node
             array('asset' => $asset, 'inputs' => $inputs, 'filters' => $filters, 'name' => $name)
         );
 
-        parent::__construct($nodes, $attributes, $lineno, $tag);
+        // Twig 3.12 deprecated passing the node tag to the constructor; the
+        // Parser now sets it automatically. Twig 2.x and Twig < 3.12 still
+        // expect it to be supplied here.
+        if (version_compare(Environment::VERSION, '3.12.0', '>=')) {
+            parent::__construct($nodes, $attributes, $lineno);
+        } else {
+            parent::__construct($nodes, $attributes, $lineno, $tag);
+        }
     }
 
     public function compile(Compiler $compiler)

--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -88,7 +88,13 @@ class AsseticTokenParser extends AbstractTokenParser
                 // vars=['locale','browser']
                 $stream->next();
                 $stream->expect(Token::OPERATOR_TYPE, '=');
-                $stream->expect(Token::PUNCTUATION_TYPE, '[');
+
+                // Twig 2 lexes the opening "[" as punctuation, Twig 3 as an operator.
+                if ($stream->test(Token::OPERATOR_TYPE, '[')) {
+                    $stream->next();
+                } else {
+                    $stream->expect(Token::PUNCTUATION_TYPE, '[');
+                }
 
                 while ($stream->test(Token::STRING_TYPE)) {
                     $attributes['vars'][] = $stream->expect(Token::STRING_TYPE)->getValue();

--- a/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
+++ b/tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php
@@ -254,6 +254,6 @@ class AsseticExtensionTest extends TestCase
 
     private function renderXml($name, $context = [])
     {
-        return new \SimpleXMLElement($this->twig->loadTemplate($name)->render($context));
+        return new \SimpleXMLElement($this->twig->load($name)->render($context));
     }
 }


### PR DESCRIPTION
## Summary

Widens the `twig/twig` dev requirement from `^2.11` to **`^2.11 || ^3.0`** so Assetic's Twig integration is exercised against Twig 3, and resolves the incompatibilities and deprecations Twig 3 surfaces. All changes are backward compatible with Twig 2.x, so existing consumers on Twig 2 are unaffected.

This also removes the first-party reason CI saw deprecation noise on PHP 8.4/8.5: the `Implicitly marking parameter … nullable` notices came from the old Twig 2.x line, which is clean on Twig 3.

## Changes

- **`composer.json`** — `twig/twig: "^2.11 || ^3.0"`. Composer resolves the highest compatible version, so CI runs against Twig 3 on PHP 8.x while Twig 2 stays supported.
- **`src/Assetic/Extension/Twig/AsseticTokenParser.php`** — Twig 3 lexes the opening `[` of a `vars=[...]` attribute list as an **operator** token rather than **punctuation**. The parser now accepts either, so `{% javascripts … vars=["foo","bar"] %}` parses on both majors. (`,` and `]` are punctuation in both and are unchanged.)
- **`src/Assetic/Extension/Twig/AsseticNode.php`** — two Twig 3 deprecations in first-party code:
  - **Twig 3.9** deprecated nodes that compile to `echo` instead of `yield`. `AsseticNode` only assigns to the context and subcompiles its body (it never emits `echo`), so it is yield-safe — marked with `#[\Twig\Attribute\YieldReady]`. The attribute is inert on Twig 2.x (never resolved) and on PHP 7.x (parses as a comment).
  - **Twig 3.12** deprecated passing the node tag to the `Node` constructor (the Parser sets it automatically now). The tag is no longer forwarded on Twig ≥ 3.12, while Twig 2.x / < 3.12 still receive it.
- **`tests/Assetic/Test/Extension/Twig/AsseticExtensionTest.php`** — the internal `Environment::loadTemplate()` signature changed in Twig 3; the test helper now uses the public `load()` method, which returns a renderable `TemplateWrapper` on both Twig 2.11+ and 3.x.

## Verification

Ran the full suite **with the `symfony/phpunit-bridge` deprecation helper enabled** (the default) — no failures, no errors, and no remaining first-party deprecations — against both Twig versions:

```
# PHP 8.3 + twig/twig v3.27.1  →  exit 0
# PHP 8.3 + twig/twig v2.16.1  →  exit 0
OK, but incomplete, skipped, or risky tests!
Tests: 408, Assertions: 547, Skipped: 61.
```

(The earlier push failed CI because the bridge correctly flagged the two first-party Twig 3 deprecations above; both are now fixed at the source rather than suppressed.) `phpcs` (PSR-12) is clean on the changed files.

## Notes

Independent of #48 (which adds 8.4/8.5 to the CI matrix and quiets the unfixable vendor deprecations); the two PRs touch disjoint files and can merge in any order. Dropping Twig 2 entirely (`^3.0` only) was deliberately avoided to preserve backward compatibility, in keeping with Assetic's wide version support.